### PR TITLE
Change getString() method calls from JSONObject by optString()

### DIFF
--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ActionEvent.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ActionEvent.kt
@@ -23,10 +23,10 @@ internal data class ActionEvent(val action: String,
                    orderId: Int,
                    time: Date,
                    threadInfo: ThreadInfo): ActionEvent {
-            val action = json.getString("action")
-            val sender = json.getString("sender")
-            val senderTitle = json.getString("senderTitle")
-            val target = json.getString("target")
+            val action = json.optString("action")
+            val sender = json.optString("sender")
+            val senderTitle = json.optString("senderTitle")
+            val target = json.optString("target")
             return ActionEvent(action, sender, senderTitle, target, orderId, time, threadInfo)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ActivityEvent.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ActivityEvent.kt
@@ -22,9 +22,9 @@ internal data class ActivityEvent(val name: String,
                    orderId: Int,
                    time: Date,
                    threadInfo: ThreadInfo): ActivityEvent {
-            val name = json.getString("name")
-            val event = json.getString("event")
-            val title = json.getString("title")
+            val name = json.optString("name")
+            val event = json.optString("event")
+            val title = json.optString("title")
             return ActivityEvent(name, event, title, orderId, time, threadInfo)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/BaseLog.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/BaseLog.kt
@@ -23,9 +23,9 @@ internal abstract class BaseLog(val type: String,
         var count = AtomicInteger(0)
 
         fun create(json: JSONObject): BaseLog {
-            val type = json.getString("type")
+            val type = json.optString("type")
             val orderId = json.getInt("orderId")
-            val time = DateHelper.createDateStandard(json.getString("time"))!!
+            val time = DateHelper.createDateStandard(json.optString("time"))!!
             val threadInfo = ThreadInfo.create(json.getJSONObject("threadInfo"))
             return when (type) {
                 "message" -> Message.create(json, orderId, time, threadInfo)
@@ -66,7 +66,7 @@ internal abstract class BaseLog(val type: String,
 
         companion object {
             fun create(json: JSONObject): ThreadInfo {
-                val threadName = json.getString("threadName")
+                val threadName = json.optString("threadName")
                 val threadId = json.getLong("threadId")
                 val isMain = json.getBoolean("isMain")
                 return  ThreadInfo(threadName, threadId, isMain)

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ConfigEvent.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ConfigEvent.kt
@@ -23,7 +23,7 @@ internal data class ConfigEvent(val orientation: Orientation,
                    orderId: Int,
                    time: Date,
                    threadInfo: ThreadInfo): ConfigEvent {
-            val orientation = Orientation.valueOf(json.getString("orientation"))
+            val orientation = Orientation.valueOf(json.optString("orientation"))
             return ConfigEvent(orientation, orderId, time, threadInfo)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ConfigResponse.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ConfigResponse.kt
@@ -58,8 +58,8 @@ internal data class ConfigResponse(val appenders: List<AppenderResponse>,
     data class AppenderResponse(val type: String, val name: String, val config: Config? = null): BaseObj {
         companion object {
             fun create(json: JSONObject): AppenderResponse {
-                val type: String = json.getString("type")
-                val name: String = json.getString("name")
+                val type: String = json.optString("type")
+                val name: String = json.optString("name")
 
 
                 var config: MutableMap<String, String>? = null
@@ -67,7 +67,7 @@ internal data class ConfigResponse(val appenders: List<AppenderResponse>,
                     config = mutableMapOf()
                     val configObject = json.getJSONObject("config")
                     configObject.keys().forEach {
-                        config.set(it, configObject.getString(it))
+                        config.set(it, configObject.optString(it))
                     }
                 }
 
@@ -92,10 +92,10 @@ internal data class ConfigResponse(val appenders: List<AppenderResponse>,
     data class LoggerResponse(val name: String, val severity: Severity, val callStackSeverity: Severity = Severity.Off, val appenderRef: String): BaseObj {
         companion object {
             fun create(json: JSONObject): LoggerResponse {
-                val name = json.getString("name")
-                val severity = Severity.valueOf(json.getString("severity"))
-                val callStackSeverity = if (json.has("callStackSeverity")) Severity.valueOf(json.getString("callStackSeverity")) else Severity.Off
-                val appenderRef = json.getString("appenderRef")
+                val name = json.optString("name")
+                val severity = Severity.valueOf(json.optString("severity", Severity.Verbose.name))
+                val callStackSeverity = if (json.has("callStackSeverity")) Severity.valueOf(json.optString("callStackSeverity", Severity.Verbose.name)) else Severity.Off
+                val appenderRef = json.optString("appenderRef")
                 return LoggerResponse(name, severity, callStackSeverity, appenderRef)
             }
         }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ErrorResponse.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ErrorResponse.kt
@@ -13,8 +13,8 @@ import org.json.JSONObject
 internal data class ErrorResponse (val name: String, val message: String, val status: Int?) {
     companion object {
         fun create(json: JSONObject): ErrorResponse {
-            val name = json.getString("name")
-            val message = json.getString("message")
+            val name = json.optString("name")
+            val message = json.optString("message")
             val status = json.optInt("status")
             return ErrorResponse(name, message, status)
         }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/FragmentEvent.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/FragmentEvent.kt
@@ -22,8 +22,8 @@ internal data class FragmentEvent(val name: String,
                    orderId: Int,
                    time: Date,
                    threadInfo: ThreadInfo): FragmentEvent {
-            val name = json.getString("name")
-            val event = json.getString("event")
+            val name = json.optString("name")
+            val event = json.optString("event")
             return FragmentEvent(name, event, orderId, time, threadInfo)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/Login.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/Login.kt
@@ -59,24 +59,24 @@ internal data class Login(
 
     companion object {
         fun create(json: JSONObject): Login {
-            val appId = json.getString("appId")
-            val appKey = json.getString("appKey")
-            val os = json.getString("os")
+            val appId = json.optString("appId")
+            val appKey = json.optString("appKey")
+            val os = json.optString("os")
             //    val bundleIdentifier: String
-            val appName = json.getString("appName")
-            val udid = json.getString("udid")
-            val time = DateHelper.createDateStandard(json.getString("time"))!!
-            val deviceTime = DateHelper.createDateStandard(json.getString("deviceTime"))!!
-            val osVersion = json.getString("osVersion")
-            val appVersion = json.getString("appVersion")
+            val appName = json.optString("appName")
+            val udid = json.optString("udid")
+            val time = DateHelper.createDateStandard(json.optString("time"))!!
+            val deviceTime = DateHelper.createDateStandard(json.optString("deviceTime"))!!
+            val osVersion = json.optString("osVersion")
+            val appVersion = json.optString("appVersion")
             val appVersionCode = json.getInt("appVersionCode")
-            val sdkVersion = json.getString("sdkVersion")
+            val sdkVersion = json.optString("sdkVersion")
             val sdkVersionCode = json.getInt("sdkVersionCode")
-            val manufacturer = json.getString("manufacturer")
-            val deviceModel = json.getString("deviceModel")
-            val deviceName = json.getString("deviceName")
+            val manufacturer = json.optString("manufacturer")
+            val deviceModel = json.optString("deviceModel")
+            val deviceName = json.optString("deviceName")
             //    var advertisementId: String? = nil
-            val language = json.getString("language")
+            val language = json.optString("language")
             val isDebug = json.getBoolean("isDebug")
             val isObfuscated = json.getBoolean("isObfuscated")
             val user = if (json.has("user")) User.create(json.optJSONObject("user")) else null

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/LoginResponse.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/LoginResponse.kt
@@ -13,9 +13,9 @@ internal data class LoginResponse(val token: String, val config: ConfigResponse,
 
     companion object {
         fun create(json: JSONObject): LoginResponse {
-            val token = json.getString("token")
+            val token = json.optString("token")
             val config = ConfigResponse.create(json.getJSONObject("config"))
-            val sessionUrl = json.getString("sessionUrl")
+            val sessionUrl = json.optString("sessionUrl")
             return LoginResponse(token, config, sessionUrl)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/Message.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/Message.kt
@@ -34,9 +34,9 @@ internal data class Message(val severity: Severity,
                    orderId: Int,
                    time: Date,
                    threadInfo: ThreadInfo): Message {
-            val tag = json.getString("tag")
-            val severity = Severity.valueOf(json.getString("severity"))
-            val message = json.getString("message")
+            val tag = json.optString("tag")
+            val severity = Severity.valueOf(json.optString("severity"))
+            val message = json.optString("message")
             val stackTrace = json.optJSONArray("stackTrace")?.toListStackTraceElement()
             val exception = if (json.has("exception")) MessageException.create(json.optJSONObject("exception")) else null
             val function = json.optString("function");

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/RefreshToken.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/RefreshToken.kt
@@ -12,8 +12,8 @@ import org.json.JSONObject
 internal data class RefreshToken(val token: String, val appKey: String): BaseObj {
     companion object {
         fun create(json: JSONObject): RefreshToken {
-            val token = json.getString("token")
-            val appKey = json.getString("appKey")
+            val token = json.optString("token")
+            val appKey = json.optString("appKey")
             return RefreshToken(token, appKey)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/RefreshTokenResponse.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/RefreshTokenResponse.kt
@@ -12,7 +12,7 @@ import org.json.JSONObject
 internal data class RefreshTokenResponse(val token: String): BaseObj {
     companion object {
         fun create(json: JSONObject): RefreshTokenResponse {
-            val token = json.getString("token")
+            val token = json.optString("token")
             return RefreshTokenResponse(token)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ScreenEvent.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/ScreenEvent.kt
@@ -20,7 +20,7 @@ internal data class ScreenEvent(val name: String,
                    orderId: Int,
                    time: Date,
                    threadInfo: ThreadInfo): ScreenEvent {
-            val name = json.getString("name")
+            val name = json.optString("name")
             return ScreenEvent(name, orderId, time, threadInfo)
         }
     }

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/StackTraceElement.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/StackTraceElement.kt
@@ -15,8 +15,8 @@ internal data class StackTraceElement (val declaringClass: String,
                                        val lineNumber: Int): BaseObj {
     companion object {
         fun create(json: JSONObject): StackTraceElement {
-            val declaringClass = json.getString("declaringClass")
-            val methodName = json.getString("methodName")
+            val declaringClass = json.optString("declaringClass")
+            val methodName = json.optString("methodName")
             val fileName = json.optString("fileName")
             val lineNumber = json.getInt("lineNumber")
             return StackTraceElement(declaringClass, methodName, fileName, lineNumber)

--- a/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/User.kt
+++ b/shipbooksdk/src/main/java/io/shipbook/shipbooksdk/Models/User.kt
@@ -18,7 +18,7 @@ internal data class User(val userId:String,
 
     companion object {
         fun create(json: JSONObject) : User {
-            val userId = json.getString("userId")
+            val userId = json.optString("userId")
             val userName = json.optString("userName", null)
             val fullName = json.optString("fullName", null)
             val email = json.optString("email", null)
@@ -28,7 +28,7 @@ internal data class User(val userId:String,
             if (additionalInfoObject != null) {
                 additionalInfo = mutableMapOf()
                 additionalInfoObject.keys().forEach {
-                    additionalInfo.set(it, additionalInfoObject.getString(it))
+                    additionalInfo.set(it, additionalInfoObject.optString(it))
                 }
             }
             return User(userId, userName, fullName, email, phoneNumber, additionalInfo)


### PR DESCRIPTION
Hey Elisha!

We have been taking a look for a while at a problem we only have on **release builds** (signed-minified-shrinked builds). No data is sent to ShipBook servers due to an initialization problem during the login phase.

 _InnerLog_ during tests give us this error:

<img width="674" alt="Screenshot 2021-07-08 at 19 57 49" src="https://user-images.githubusercontent.com/2458146/124969282-cd240100-e026-11eb-9a90-91c1671b06e2.png">


We took a look at the JSON responses sent from the servers and the only thing we found around that _maxTime_ field was it had a int value instead of a string.

``` json
{"token":"...","config":{"loggers":[{"appenderRef":"cloud","severity":"Verbose","name":""},{"appenderRef":"console","severity":"Verbose","name":""}],"appenders":[{"config":{"flushSeverity":"Verbose","maxTime":3},"name":"cloud","type":"SBCloudAppender"},{"config":{"pattern":"$message"},"name":"console","type":"ConsoleAppender"}]},"sessionUrl":"..."}
```

We were confused because `getString()` method from `JSONObject` handles that and makes a `valueOf()` the int in order to get the string, so where was the problem with that?

After investigation of the issue, we finally see that the issue is only reproducible on release builds with **ProGuard** activated. 

That made us think about a relationship between obfuscation and json dependency, maybe the JSONObject in the release built was not the same as we thought.

We can confirm that we are using in our app the _org.json_ dependency from https://github.com/stleary/JSON-java instead of the Android platform default one, and this is a so common used library. They should have same behaviour, but they don't , lets see the `getString()` method https://github.com/stleary/JSON-java/blob/20210307/src/main/java/org/json/JSONObject.java#L858

Differences between _getString()_ from org.json Android and org.json stleary:

```
    /**
     * Returns the value mapped by {@code name} if it exists, coercing it if
     * necessary, or throws if no such mapping exists.
     *
     * @throws JSONException if no such mapping exists.
     */
    @NonNull public String getString(@NonNull String name) throws JSONException {
        Object object = get(name);
        String result = JSON.toString(object);
        if (result == null) {
            throw JSON.typeMismatch(name, object, "String");
        }
        return result;
    }
```
_Android framework_

```
    /**
     * Get the string associated with a key.
     *
     * @param key
     *            A key string.
     * @return A string which is the value.
     * @throws JSONException
     *             if there is no string value for the key.
     */
    public String getString(String key) throws JSONException {
        Object object = this.get(key);
        if (object instanceof String) {
            return (String) object;
        }
        throw wrongValueFormatException(key, "string", null);
    }
```
_org.json from stleary_


It has different behaviour for non string params, unlike the Android org.json framework does. The thing is they share naming.

Why this only happens on release builds (debug builds hasn't this problem) ? This is because **ProGuard** and code obfuscation. org.json dependency is already satisfied by the Android framework but after code is obfuscated those dependencies are renamed and forces the app to use the one provided by dependencies.

We are aware this is not a ShipBook's problem, but we think that if JSON parsing source code uses safer methods from the Android org.json it could avoid those kind of problems on every library client, no matter what org.json code they are using.

Let me know if you find this interesting, if you have any doubt, just let me know, hope it helps

thank you!