### PR TITLE
Avoid casting for the default maxTime value

### DIFF
--- a/shipbooksdk/src/main/res/raw/config.json
+++ b/shipbooksdk/src/main/res/raw/config.json
@@ -12,7 +12,7 @@
       "name" : "cloud",
       "config" :
       {
-        "maxTime" : 5,
+        "maxTime" : "5",
         "flushSeverity" : "Warning"
       }
     }],


### PR DESCRIPTION
As the sdk is parsing this configuration as String, this avoids the casting (made by the JSON library internally) when it is parsing the default values. This is related to https://github.com/ShipBook/ShipBookSDK-Android/pull/6